### PR TITLE
fix(actor): avoid websocket global in unit test helper

### DIFF
--- a/test/unit/actor/connection-actor.test.ts
+++ b/test/unit/actor/connection-actor.test.ts
@@ -18,6 +18,8 @@ vi.mock('../../../src/actor/attachment', () => ({
 
 import { createConnectionHandler } from '../../../src/actor/connection-actor';
 
+const WEBSOCKET_OPEN = 1;
+
 function createMockStorage(initial: Record<string, unknown> = {}) {
 	const store = new Map<string, unknown>(Object.entries(initial));
 
@@ -51,7 +53,7 @@ function createMockContext() {
 
 function createMockSocket() {
 	return {
-		readyState: WebSocket.OPEN,
+		readyState: WEBSOCKET_OPEN,
 		close: vi.fn(),
 		send: vi.fn(),
 		deserializeAttachment: vi.fn(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the new connection actor test helper's `WebSocket.OPEN` usage with a local open-state constant
- keep the room binding tests compatible with the plain `vitest.unit.config.mts` runtime used by CI

## Testing
- bun run test:unit
- bun x tsc --noEmit
- bun run build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-deb716f9-d8a3-4149-9f93-df3aabb68c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deb716f9-d8a3-4149-9f93-df3aabb68c01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

